### PR TITLE
More testing

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,6 @@
 boto==2.39.0
 cffi==1.8.3
+coverage==4.2
 cryptography==1.5.1
 dj-database-url==0.4.0
 Django==1.10.1

--- a/web/test-coverage.sh
+++ b/web/test-coverage.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+bash ./wait-for-it.sh -t 30 -h postgres -p 5432;
+bash setup.sh;
+coverage run --source='turkey' turkey/manage.py test survey.tests;
+coverage report;

--- a/web/turkey/survey/models.py
+++ b/web/turkey/survey/models.py
@@ -74,7 +74,6 @@ class Task(Model):
     survey_wrap_template = 'survey/survey_default_template.html'
     lobby_template = 'survey/lobby_default_template.html'
 
-    # TODO: Actually enforce this
     owners = models.ManyToManyField(
         User,
         verbose_name=_('Owners'),
@@ -193,7 +192,6 @@ class AuditorData(_DataModel):
     #                                                  field you must implement
 
 
-# TODO: Should inherit from Model, but this causes field clashes, necessitating inheriting Model as well in some classes. Bad stuff.
 class _TaskLinkedModel(Model):
     task = models.ForeignKey(
         'Task',

--- a/web/turkey/survey/models.py
+++ b/web/turkey/survey/models.py
@@ -130,9 +130,6 @@ class Task(Model):
                 raise ValidationError(_('Can\'t change whether the HIT is '
                                         'internal or external because there '
                                         'is already collected data'))
-            if not self.published:
-                raise ValidationError(_('Can\'t unpublish task as there is '
-                                        'already collected data'))
 
         if not self.external and not self.survey_name:
             raise ValidationError(_('%s cannot be blank because this is not '

--- a/web/turkey/survey/tests.py
+++ b/web/turkey/survey/tests.py
@@ -1,29 +1,95 @@
+import json
+
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.test import Client
 from django.test import TestCase
 
 # Create your tests here.
-from .models import Task, Token, TaskInteraction, StepTextInput
+from django.urls import reverse
+from rest_framework import status
+
+from .models import Task, Token, TaskInteraction, StepTextInput, AuditorClicksTotal
 
 
 class AbstractTestCase(TestCase):
+    TASK_IS_EXTERNAL = False
+    TASK_IS_PUBLISHED = True
+
     def setUp(self):
         self.admin_user = User.objects.create_user('admin', 'admin@admin.com', 'adminpassword')
+        self.internal_task = Task(survey_name='Bestest Task',
+                                  external=self.TASK_IS_EXTERNAL,
+                                  published=self.TASK_IS_PUBLISHED)
+        self.internal_task.save()
+        self.internal_task.owners.add(self.admin_user)
+        self.token = Token.objects.create()
+        self.client = Client()
+
+
+class BasicAuditorSubmissionTestCase(AbstractTestCase):
+    SUBMISSION_OBJECTS_KEY = 'auditors'
+
+    def create_task_interaction(self):
+        return TaskInteraction.objects.create(task=self.internal_task,
+                                              token=self.token)
+
+    def post_basic_submission(self, interaction):
+        return self.post_json_submission(interaction,
+                                         {'token': self.token.token.decode(),
+                                          self.SUBMISSION_OBJECTS_KEY: {}})
+
+    def post_json_submission(self, interaction, data):
+        return self.client.post(reverse('survey:auditor_submission',
+                                        kwargs={'pk': interaction.task.pk}),
+                                content_type='application/json',
+                                data=json.dumps(data))
+
+    def test_cant_submit_to_unpublished_task(self):
+        self.internal_task.published = False
+        self.internal_task.save()
+        response = self.post_basic_submission(self.create_task_interaction())
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_can_submit_to_published_task(self):
+        response = self.post_basic_submission(self.create_task_interaction())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_cant_double_submit(self):
+        AuditorClicksTotal.objects.create(task=self.internal_task)
+        interaction = self.create_task_interaction()
+        response = self.post_json_submission(
+            interaction,
+            {
+                'token': self.token.token.decode(),
+                self.SUBMISSION_OBJECTS_KEY: {
+                    'clicks_total': {
+                        'count': 5
+                    }
+                }
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.post_json_submission(
+            interaction,
+            {
+                'token': self.token.token.decode(),
+                self.SUBMISSION_OBJECTS_KEY: {
+                    'clicks_total': {
+                        'count': 5
+                    }
+                }
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TokenSanityChecks(AbstractTestCase):
     def test_can_create(self):
         Token.objects.create()
 
-class TaskSanityChecks(AbstractTestCase):
-    def setUp(self):
-        super().setUp()
-        self.internal_task = Task(survey_name='Bestest Task',
-                                  external=False,
-                                  published=True)
-        self.internal_task.save()
-        self.internal_task.owners.add(self.admin_user)
-        self.token = Token.objects.create()
 
+class TaskSanityChecks(AbstractTestCase):
     def test_can_modify_without_submission(self):
         self.internal_task.survey_name = 'Worstest Task'
         self.internal_task.full_clean()
@@ -67,15 +133,8 @@ class TaskSanityChecks(AbstractTestCase):
 
         self.invalid_task_modification(mod)
 
-
     def test_cant_modify_external_status_after_submission(self):
         def mod(task):
             task.external = True
-
-        self.invalid_task_modification(mod)
-
-    def test_cant_unpublish(self):
-        def mod(task):
-            task.published = False
 
         self.invalid_task_modification(mod)

--- a/web/turkey/survey/tests.py
+++ b/web/turkey/survey/tests.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 
-from .models import Task, Token, TaskInteraction, StepTextInput, AuditorClicksTotal
+from .models import Task, Token, TaskInteraction, StepTextInput, AuditorClicksTotal, AuditorClicksTotalData
 
 
 class AbstractTestCase(TestCase):
@@ -82,6 +82,27 @@ class BasicAuditorSubmissionTestCase(AbstractTestCase):
             }
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_auditor_submission_serialized(self):
+        """
+        Test with one of the basic auditors that things are properly going to the database.
+        """
+        auditor = AuditorClicksTotal.objects.create(task=self.internal_task)
+        interaction = self.create_task_interaction()
+        self.post_json_submission(
+            interaction,
+            {
+                'token': self.token.token.decode(),
+                self.SUBMISSION_OBJECTS_KEY: {
+                    'clicks_total': {
+                        'count': 5
+                    }
+                }
+            }
+        )
+        data = AuditorClicksTotalData.objects.filter(general_model=auditor)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0].count, 5)
 
 
 class TokenSanityChecks(AbstractTestCase):

--- a/web/turkey/survey/tests.py
+++ b/web/turkey/survey/tests.py
@@ -3,25 +3,57 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 # Create your tests here.
-from .models import Task, Token, TaskInteraction
+from .models import Task, Token, TaskInteraction, StepTextInput
 
 
 class AbstractTestCase(TestCase):
     def setUp(self):
         self.admin_user = User.objects.create_user('admin', 'admin@admin.com', 'adminpassword')
 
+class TokenSanityChecks(AbstractTestCase):
+    def test_can_create(self):
+        Token.objects.create()
 
 class TaskSanityChecks(AbstractTestCase):
     def setUp(self):
         super().setUp()
-        self.task = Task(survey_name='Bestest Task',
-                         external=False)
-        self.task.save()
-        self.task.owners.add(
-            User.objects.create_user('admin1234', 'admin@admin.com', 'adminpassword')
-        )
+        self.internal_task = Task(survey_name='Bestest Task',
+                                  external=False,
+                                  published=True)
+        self.internal_task.save()
+        self.internal_task.owners.add(self.admin_user)
+        self.token = Token.objects.create()
 
-    def test_cant_modify_after_submission(self):
+    def test_can_modify_without_submission(self):
+        self.internal_task.survey_name = 'Worstest Task'
+        self.internal_task.full_clean()
+        self.internal_task.save()
+
+    def test_cant_change_test_to_external_without_deleting_steps(self):
+        step = StepTextInput.objects.create(task=self.internal_task,
+                                            title='Are you truly happy',
+                                            text='If you lie you\'re only '
+                                                 'hurting yourself',
+                                            step_num=1)
+        self.internal_task.external = True
+        with self.assertRaises(ValidationError):
+            self.internal_task.full_clean()
+        step.delete()
+        self.internal_task.full_clean()
+
+    def invalid_task_modification(self, modification_function):
+        TaskInteraction.objects.create(token=self.token,
+                                       task=self.internal_task)
+        modification_function(self.internal_task)
+        with self.assertRaises(ValidationError):
+            self.internal_task.full_clean()
+
+    def test_cant_make_unnamed_internal_task(self):
+        task = Task(survey_name='', external=False)
+        with self.assertRaises(ValidationError):
+            task.full_clean()
+
+    def test_cant_modify_name_after_submission(self):
         """
         Tests whether we are keeping users from modifying tasks after
         users have already submitted responses, or auditors have already
@@ -29,9 +61,21 @@ class TaskSanityChecks(AbstractTestCase):
 
         Any user interaction is represented by a task interaction.
         """
-        TaskInteraction.objects.create(token=Token.objects.create(),
-                                       task=self.task)
-        # assert that the below creates a ValidationError
-        self.task.survey_name = 'Worstest Task'
-        with self.assertRaises(ValidationError):
-            self.task.full_clean()
+
+        def mod(task):
+            task.survey_name = 'Worstest'
+
+        self.invalid_task_modification(mod)
+
+
+    def test_cant_modify_external_status_after_submission(self):
+        def mod(task):
+            task.external = True
+
+        self.invalid_task_modification(mod)
+
+    def test_cant_unpublish(self):
+        def mod(task):
+            task.published = False
+
+        self.invalid_task_modification(mod)

--- a/web/turkey/survey/tests.py
+++ b/web/turkey/survey/tests.py
@@ -104,6 +104,22 @@ class BasicAuditorSubmissionTestCase(AbstractTestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].count, 5)
 
+    def test_junk_data_returns_bad_request(self):
+        AuditorClicksTotal.objects.create(task=self.internal_task)
+        interaction = self.create_task_interaction()
+        response = self.post_json_submission(
+            interaction,
+            {
+                'token': self.token.token.decode(),
+                self.SUBMISSION_OBJECTS_KEY: {
+                    'clicks_total': {
+                        'count': 'fish'
+                    }
+                }
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TokenSanityChecks(AbstractTestCase):
     def test_can_create(self):

--- a/web/turkey/survey/views.py
+++ b/web/turkey/survey/views.py
@@ -1,3 +1,4 @@
+import django
 from django.apps import apps
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.staticfiles.templatetags.staticfiles import static
@@ -6,7 +7,6 @@ from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import Http404, StreamingHttpResponse
 from django.template.response import TemplateResponse
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
 from rest_framework import status
@@ -123,6 +123,8 @@ class RecordSubmission(APIView):
                 self.process_submission(request.data, task_interaction_model)
                 return Response(status=status.HTTP_201_CREATED)
             except ValidationError:
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+            except django.core.exceptions.ValidationError:
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/web/turkey/survey/views.py
+++ b/web/turkey/survey/views.py
@@ -117,6 +117,8 @@ class RecordSubmission(APIView):
             task_interaction_model = self.get_task_interaction(kwargs['pk'], request)
             if not task_interaction_model:
                 return Response(status=status.HTTP_400_BAD_REQUEST)
+            if not task_interaction_model.task.published:
+                return Response(status=status.HTTP_404_NOT_FOUND)
             try:
                 self.process_submission(request.data, task_interaction_model)
                 return Response(status=status.HTTP_201_CREATED)


### PR DESCRIPTION
Change framework so that tasks can be unpublished as well as published. Introduce basic sanity checking around task creation and modification. Introduce basic sanity checking around auditor data submission as well. Finally, introduce a basic check on Token creation because it has a custom object manager.
